### PR TITLE
fix: correct typos in package.json and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,14 +197,14 @@ export class AppModule {}
 
 ### 2. Use a specific agent
 
-o use a specific agent in your services, use the @InjectAgent() decorator with the corresponding name:
+To use a specific agent in your services, use the @InjectAgent() decorator with the corresponding name:
 
 ```ts
 @Injectable()
 export class AppService {
   constructor(
     @InjectAgent('MATH_AGENT') private readonly mathAgent: LangChainService,
-    @InjectAgent('SUPPORT_AGENT')
+    @InjectAgent('MONGO_AGENT')
     private readonly supportAgent: LangChainService,
   ) {}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nestjs-langchain",
   "version": "1.0.1",
-  "description": "NestJS librairy to build agent with LangChain",
+  "description": "NestJS library to build agents with LangChain",
   "keywords": [
     "nestjs",
     "langchain",


### PR DESCRIPTION
## Summary

Fixed 3 typos reported in issue #31:

1. **package.json**: `librairy` → `library`, `agent` → `agents`
2. **README.md**: `o use a specific agent` → `To use a specific agent` (missing T)
3. **README.md**: `@InjectAgent('SUPPORT_AGENT')` → `@InjectAgent('MONGO_AGENT')` to match the registered agent name in the example

## Changes

- 2 files changed, 3 insertions, 3 deletions
- Surgical fix: only the reported typos were corrected

---

This is my first contribution to this repo — happy to address any feedback!